### PR TITLE
v1.1.6 にアップデート

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to the "securezip" extension will be documented in this file
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.1.6] - 2026-01-16
+
+- Added a tagging mode setting so exports can ask, always tag, or skip tagging entirely.
+- Improved existing-tag handling with clearer choices to reuse, propose a new tag, or skip tagging.
+
 ## [1.1.5] - 2026-01-14
 
 - Added `.securezipignore` hover previews for file, directory, and glob patterns, including file snippets.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "securezip",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "securezip",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "dependencies": {
         "archiver": "^7.0.1",
         "globby": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "SecureZip",
   "description": "Securely export your project as a clean ZIP.",
   "publisher": "yugook",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "icon": "resources/securezip.png",
   "repository": {
     "type": "git",


### PR DESCRIPTION
新しいタグ付けモードと、エクスポートフローにおける既存タグの処理改善を反映した変更履歴エントリを追加しました。

詳細:

- package.json のバージョンを更新し、package-lock.json のメタデータを同期することで、npm の出力の一貫性を維持しました。
- タグ付けモードオプションと既存タグの競合に関する選択肢について、2026年1月16日付の CHANGELOG.md に新しいリリースノートを追加しました。