### PR TITLE
github-actions[bot] の 403 は GITHUB_TOKEN の権限不足が原因なので、ワークフロー側で content…

### DIFF
--- a/.github/workflows/cleanup-preview-tags.yml
+++ b/.github/workflows/cleanup-preview-tags.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 3 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest


### PR DESCRIPTION
…s: write を明示

変更内容
.github/workflows/cleanup-preview-tags.yml に permissions: contents: write を追加して、タグ削除に必要な権限を付与しました。