### PR TITLE
v1.1.8に変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the "securezip" extension will be documented in this file
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
+## [1.1.8] - 2026-02-19
+
+- Added full multi-root workspace support for target resolution and export behavior.
+- Added a dedicated `securezip.exportWorkspace` command to create a single ZIP from all workspace folders.
+- Updated the SecureZip view to group by repository/folder in multi-root workspaces with per-group Guide/Actions/Preview/Recent sections.
+- Restored single-folder behavior so the export mode prompt is skipped and the status bar keeps the classic label.
+- Improved empty-export handling to report a clear error when all files are excluded.
+- Added and aligned multi-root design documentation in `docs/multi-root-workspaces.md` and README links.
+
 ## [1.1.7] - 2026-02-18
 
 - User-facing: Refined the extension icon for better visibility in the VS Code Marketplace.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "securezip",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "securezip",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "dependencies": {
         "archiver": "^7.0.1",
         "globby": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "SecureZip",
   "description": "Securely export your project as a clean ZIP.",
   "publisher": "yugook",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "icon": "resources/securezip.png",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 変更内容
  - `package.json` のバージョンを `1.1.7` → `1.1.8` に更新
  - `package-lock.json` のバージョンを `1.1.7` → `1.1.8` に更新
  - `CHANGELOG.md` に `1.1.8 (2026-02-19)` を追加
    - multi-root workspace 対応
    - `securezip.exportWorkspace` コマンド追加
    - SecureZip view のグルーピング改善
    - 単一フォルダ時の既存挙動維持
    - 全除外時エラーの明確化
    - multi-root 関連ドキュメント更新