### PR TITLE
fix(ci): use merge commit for dependabot auto-merge

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -98,4 +98,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           pull-request-number: ${{ github.event.pull_request.number }}
-          merge-method: squash
+          merge-method: merge


### PR DESCRIPTION
リポジトリのルールでsquashを禁止しているのでマージコミットに変更