### PR TITLE
v1.1.9 リリース準備

### DIFF
--- a/.github/workflows/marketplace-pat-check.yml
+++ b/.github/workflows/marketplace-pat-check.yml
@@ -1,9 +1,14 @@
 name: Marketplace PAT Check
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
 
 permissions:
   contents: read
@@ -12,32 +17,38 @@ jobs:
   validate-release-pr:
     name: Validate release PR metadata
     if: >-
-      startsWith(github.head_ref, 'release/') &&
+      startsWith(github.event.pull_request.head.ref, 'release/') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       !github.event.pull_request.draft
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
+      - name: Checkout trusted base
         uses: actions/checkout@v7
         with:
-          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 1
+
+      - name: Fetch release pull request head
+        run: git fetch --no-tags --depth=1 origin "+refs/pull/${{ github.event.pull_request.number }}/head:refs/release-check/head"
 
       - name: Validate release version metadata
         id: version
+        env:
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          RELEASE_HEAD_REF: refs/release-check/head
         run: |
           set -euo pipefail
 
-          git fetch origin "$GITHUB_BASE_REF" --depth=1
-
-          BASE_VERSION="$(git show FETCH_HEAD:package.json | jq -r '.version')"
-          HEAD_VERSION="$(jq -r '.version' package.json)"
-          LOCK_VERSION="$(jq -r '.version' package-lock.json)"
-          LOCK_ROOT_VERSION="$(jq -r '.packages[""].version' package-lock.json)"
-          BRANCH_VERSION="${GITHUB_HEAD_REF#release/}"
+          BASE_VERSION="$(git show "${PR_BASE_SHA}:package.json" | jq -r '.version')"
+          HEAD_VERSION="$(git show "${RELEASE_HEAD_REF}:package.json" | jq -r '.version')"
+          LOCK_VERSION="$(git show "${RELEASE_HEAD_REF}:package-lock.json" | jq -r '.version')"
+          LOCK_ROOT_VERSION="$(git show "${RELEASE_HEAD_REF}:package-lock.json" | jq -r '.packages[""].version')"
+          BRANCH_VERSION="${PR_HEAD_REF#release/}"
           BRANCH_VERSION="${BRANCH_VERSION#v}"
-          SBOM_REF="$(jq -r '.metadata.component["bom-ref"]' dist/securezip-sbom.cdx.json)"
-          SBOM_VERSION="$(jq -r '.metadata.component.version' dist/securezip-sbom.cdx.json)"
+          SBOM_REF="$(git show "${RELEASE_HEAD_REF}:dist/securezip-sbom.cdx.json" | jq -r '.metadata.component["bom-ref"]')"
+          SBOM_VERSION="$(git show "${RELEASE_HEAD_REF}:dist/securezip-sbom.cdx.json" | jq -r '.metadata.component.version')"
 
           echo "base=$BASE_VERSION" >> "$GITHUB_OUTPUT"
           echo "head=$HEAD_VERSION" >> "$GITHUB_OUTPUT"
@@ -72,7 +83,7 @@ jobs:
             exit 1
           fi
 
-          if ! grep -Fq "## [${HEAD_VERSION}] -" CHANGELOG.md; then
+          if ! git show "${RELEASE_HEAD_REF}:CHANGELOG.md" | grep -Fq "## [${HEAD_VERSION}] -"; then
             echo "::error::CHANGELOG.md must contain a release entry for ${HEAD_VERSION}."
             exit 1
           fi
@@ -88,7 +99,7 @@ jobs:
     name: Verify Marketplace PAT
     needs: validate-release-pr
     if: >-
-      startsWith(github.head_ref, 'release/') &&
+      startsWith(github.event.pull_request.head.ref, 'release/') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
       !github.event.pull_request.draft
     environment: marketplace-pat

--- a/.github/workflows/marketplace-pat-check.yml
+++ b/.github/workflows/marketplace-pat-check.yml
@@ -9,7 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  check-vsce-pat:
+  validate-release-pr:
+    name: Validate release PR metadata
     if: >-
       startsWith(github.head_ref, 'release/') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
@@ -19,6 +20,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Validate release version metadata
         id: version
@@ -39,6 +42,11 @@ jobs:
           echo "base=$BASE_VERSION" >> "$GITHUB_OUTPUT"
           echo "head=$HEAD_VERSION" >> "$GITHUB_OUTPUT"
 
+          if [[ ! "$BASE_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::base package.json version must be plain semver (x.y.z), got '$BASE_VERSION'."
+            exit 1
+          fi
+
           if [[ ! "$HEAD_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::error::package.json version must be plain semver (x.y.z), got '$HEAD_VERSION'."
             exit 1
@@ -46,6 +54,11 @@ jobs:
 
           if [ "$BASE_VERSION" = "$HEAD_VERSION" ]; then
             echo "::error::release/* PRs must change package.json version."
+            exit 1
+          fi
+
+          if [ "$(printf '%s\n%s\n' "$BASE_VERSION" "$HEAD_VERSION" | sort -V | tail -n1)" != "$HEAD_VERSION" ]; then
+            echo "::error::package.json version must be greater than base version: $BASE_VERSION -> $HEAD_VERSION."
             exit 1
           fi
 
@@ -71,6 +84,17 @@ jobs:
 
           echo "Release version changed: $BASE_VERSION -> $HEAD_VERSION"
 
+  verify-marketplace-pat:
+    name: Verify Marketplace PAT
+    needs: validate-release-pr
+    if: >-
+      startsWith(github.head_ref, 'release/') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !github.event.pull_request.draft
+    environment: marketplace-pat
+    runs-on: ubuntu-latest
+
+    steps:
       - name: Check Marketplace PAT expiry metadata
         env:
           VSCE_PAT_EXPIRES_AT: ${{ vars.VSCE_PAT_EXPIRES_AT }}
@@ -78,7 +102,7 @@ jobs:
           set -euo pipefail
 
           if [ -z "${VSCE_PAT_EXPIRES_AT:-}" ]; then
-            echo "::error::Repository variable VSCE_PAT_EXPIRES_AT is required in YYYY-MM-DD format."
+            echo "::error::Environment variable VSCE_PAT_EXPIRES_AT is required in YYYY-MM-DD format."
             exit 1
           fi
 
@@ -90,24 +114,25 @@ jobs:
           try:
               expires = dt.date.fromisoformat(os.environ["VSCE_PAT_EXPIRES_AT"])
           except ValueError:
-              sys.exit("VSCE_PAT_EXPIRES_AT must use YYYY-MM-DD format.")
+              print("::error::VSCE_PAT_EXPIRES_AT must use YYYY-MM-DD format.")
+              sys.exit(1)
 
           today = dt.datetime.now(dt.timezone.utc).date()
           days = (expires - today).days
           print(f"VSCE_PAT expires in {days} days ({expires.isoformat()})")
 
           if days < 14:
-              sys.exit("VSCE_PAT expires too soon for a release PR.")
+              print("::error::VSCE_PAT expires too soon for a release PR.")
+              sys.exit(1)
           PY
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '22.20.0'
-          cache: 'npm'
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Install pinned vsce
+        run: npm install --global --ignore-scripts --no-audit --no-fund @vscode/vsce@3.9.2
 
       - name: Verify Marketplace publish rights
         env:
@@ -116,8 +141,8 @@ jobs:
           set -euo pipefail
 
           if [ -z "${VSCE_PAT:-}" ]; then
-            echo "::error::Secret VSCE_PAT is required."
+            echo "::error::Environment secret VSCE_PAT is required."
             exit 1
           fi
 
-          npx vsce verify-pat yugook
+          vsce verify-pat yugook

--- a/.github/workflows/marketplace-pat-check.yml
+++ b/.github/workflows/marketplace-pat-check.yml
@@ -1,0 +1,123 @@
+name: Marketplace PAT Check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  check-vsce-pat:
+    if: >-
+      startsWith(github.head_ref, 'release/') &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Validate release version metadata
+        id: version
+        run: |
+          set -euo pipefail
+
+          git fetch origin "$GITHUB_BASE_REF" --depth=1
+
+          BASE_VERSION="$(git show FETCH_HEAD:package.json | jq -r '.version')"
+          HEAD_VERSION="$(jq -r '.version' package.json)"
+          LOCK_VERSION="$(jq -r '.version' package-lock.json)"
+          LOCK_ROOT_VERSION="$(jq -r '.packages[""].version' package-lock.json)"
+          BRANCH_VERSION="${GITHUB_HEAD_REF#release/}"
+          BRANCH_VERSION="${BRANCH_VERSION#v}"
+          SBOM_REF="$(jq -r '.metadata.component["bom-ref"]' dist/securezip-sbom.cdx.json)"
+          SBOM_VERSION="$(jq -r '.metadata.component.version' dist/securezip-sbom.cdx.json)"
+
+          echo "base=$BASE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "head=$HEAD_VERSION" >> "$GITHUB_OUTPUT"
+
+          if [[ ! "$HEAD_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::package.json version must be plain semver (x.y.z), got '$HEAD_VERSION'."
+            exit 1
+          fi
+
+          if [ "$BASE_VERSION" = "$HEAD_VERSION" ]; then
+            echo "::error::release/* PRs must change package.json version."
+            exit 1
+          fi
+
+          if [ "$BRANCH_VERSION" != "$HEAD_VERSION" ]; then
+            echo "::error::release branch version '$BRANCH_VERSION' must match package.json version '$HEAD_VERSION'."
+            exit 1
+          fi
+
+          if [ "$LOCK_VERSION" != "$HEAD_VERSION" ] || [ "$LOCK_ROOT_VERSION" != "$HEAD_VERSION" ]; then
+            echo "::error::package-lock.json versions must match package.json version '$HEAD_VERSION'."
+            exit 1
+          fi
+
+          if ! grep -Fq "## [${HEAD_VERSION}] -" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md must contain a release entry for ${HEAD_VERSION}."
+            exit 1
+          fi
+
+          if [ "$SBOM_REF" != "securezip@${HEAD_VERSION}" ] || [ "$SBOM_VERSION" != "$HEAD_VERSION" ]; then
+            echo "::error::dist/securezip-sbom.cdx.json must reference securezip@${HEAD_VERSION}."
+            exit 1
+          fi
+
+          echo "Release version changed: $BASE_VERSION -> $HEAD_VERSION"
+
+      - name: Check Marketplace PAT expiry metadata
+        env:
+          VSCE_PAT_EXPIRES_AT: ${{ vars.VSCE_PAT_EXPIRES_AT }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${VSCE_PAT_EXPIRES_AT:-}" ]; then
+            echo "::error::Repository variable VSCE_PAT_EXPIRES_AT is required in YYYY-MM-DD format."
+            exit 1
+          fi
+
+          python3 - <<'PY'
+          import datetime as dt
+          import os
+          import sys
+
+          try:
+              expires = dt.date.fromisoformat(os.environ["VSCE_PAT_EXPIRES_AT"])
+          except ValueError:
+              sys.exit("VSCE_PAT_EXPIRES_AT must use YYYY-MM-DD format.")
+
+          today = dt.datetime.now(dt.timezone.utc).date()
+          days = (expires - today).days
+          print(f"VSCE_PAT expires in {days} days ({expires.isoformat()})")
+
+          if days < 14:
+              sys.exit("VSCE_PAT expires too soon for a release PR.")
+          PY
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22.20.0'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify Marketplace publish rights
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "${VSCE_PAT:-}" ]; then
+            echo "::error::Secret VSCE_PAT is required."
+            exit 1
+          fi
+
+          npx vsce verify-pat yugook

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   publish-preview:
     runs-on: ubuntu-latest
+    environment: marketplace-pat
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
   publish-release:
     if: ${{ (github.event_name == 'push' && !endsWith(github.ref_name, '-preview')) || (github.event_name == 'workflow_call' && !endsWith(inputs.tag_name || '', '-preview')) }}
     runs-on: ubuntu-latest
+    environment: marketplace-pat
 
     steps:
       - name: Checkout repository

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ All notable changes to the "securezip" extension will be documented in this file
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-## [1.2.1] - Unreleased
+## [1.1.9] - 2026-06-29
 
-- Added `SecureZip: Export Encrypted ZIP` and `SecureZip: Export Workspace Encrypted ZIP` commands that produce password-protected archives using WinZip AES-256 (method 99).
-- Encrypted export prompts twice for the password (entry + confirmation), re-prompts on mismatch, and aborts cleanly without writing any file when either prompt is cancelled.
-- Output is staged in a temporary `.partial` file and renamed atomically on success; failures during write or rename clean up the temp file and preserve the existing ZIP at the destination.
-- Concurrent export invocations are now rejected with an "Export is already running" warning so two runs cannot interleave.
-- Documented WinZip AES-256 compatibility, the metadata that the format does *not* protect (filenames, sizes, structure), and the case where Git auto-commit/tag may already be applied if a later step fails.
+- Added `SecureZip: Export Encrypted ZIP` and `SecureZip: Export Workspace Encrypted ZIP` commands that create password-protected archives using WinZip AES-256 (method 99).
+- Added password confirmation, mismatch retry, and clean cancellation handling so encrypted exports do not write a file when either prompt is cancelled.
+- Improved ZIP replacement safety by writing to temporary `.partial` files, preserving existing destination archives on failure, excluding destination/partial files from exports, and applying existing archive permissions best-effort.
+- Added determinate ZIP progress reporting and rejected concurrent export invocations with an "Export is already running" warning.
+- Expanded encrypted export and archive replacement coverage, including integration tests and documentation in README and architecture notes.
+- Updated CI, security, and dependency maintenance, including npm audit/signature gates, Dependabot auto-merge rules, `actions/checkout@v7`, `@vscode/test-electron@3.0.0`, and current build/lint dependency updates.
 
 ## [1.1.8] - 2026-02-19
 

--- a/dist/securezip-sbom.cdx.json
+++ b/dist/securezip-sbom.cdx.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.5",
-  "serialNumber": "urn:uuid:7ec59e74-7a10-4a4d-ac8b-8355e86b461c",
+  "serialNumber": "urn:uuid:f3a00ce0-b3be-4e13-b688-db3b2ccf0839",
   "version": 1,
   "metadata": {
-    "timestamp": "2026-06-28T04:27:41.161Z",
+    "timestamp": "2026-06-29T14:08:11.521Z",
     "lifecycles": [
       {
         "phase": "pre-build"
@@ -19,13 +19,13 @@
       }
     ],
     "component": {
-      "bom-ref": "securezip@1.1.8",
+      "bom-ref": "securezip@1.1.9",
       "type": "application",
       "name": "SecureZip",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "scope": "required",
       "description": "Securely export your project as a clean ZIP.",
-      "purl": "pkg:npm/securezip@1.1.8",
+      "purl": "pkg:npm/securezip@1.1.9",
       "properties": [
         {
           "name": "cdx:npm:package:path",
@@ -1073,6 +1073,39 @@
       ]
     },
     {
+      "bom-ref": "normalize-path@3.0.0",
+      "type": "library",
+      "name": "normalize-path",
+      "version": "3.0.0",
+      "scope": "required",
+      "purl": "pkg:npm/normalize-path@3.0.0",
+      "properties": [
+        {
+          "name": "cdx:npm:package:path",
+          "value": "node_modules/normalize-path"
+        }
+      ],
+      "externalReferences": [
+        {
+          "type": "distribution",
+          "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-512",
+          "content": "e9e66ce4bb375ad0a2b075a9f52d86532f1daa4a468b80554b3dc66aa884e9ecee6f4e75d844b3b57530501e82e8829b4246363e76ff983e166288c24707302c"
+        }
+      ],
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT"
+          }
+        }
+      ]
+    },
+    {
       "bom-ref": "process@0.11.10",
       "type": "library",
       "name": "process",
@@ -1405,7 +1438,7 @@
   ],
   "dependencies": [
     {
-      "ref": "securezip@1.1.8",
+      "ref": "securezip@1.1.9",
       "dependsOn": [
         "archiver@7.0.1",
         "archiver-zip-encrypted@2.0.0",
@@ -1462,6 +1495,7 @@
       "dependsOn": [
         "is-stream@2.0.1",
         "lazystream@1.0.1",
+        "normalize-path@3.0.0",
         "readable-stream@4.7.0"
       ]
     },
@@ -1507,6 +1541,7 @@
         "crc-32@1.2.2",
         "crc32-stream@6.0.0",
         "is-stream@2.0.1",
+        "normalize-path@3.0.0",
         "readable-stream@4.7.0"
       ]
     },
@@ -1582,6 +1617,10 @@
       "dependsOn": [
         "safe-buffer@5.1.2"
       ]
+    },
+    {
+      "ref": "normalize-path@3.0.0",
+      "dependsOn": []
     },
     {
       "ref": "process@0.11.10",

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -58,9 +58,12 @@ never consume the number intended for the next stable release.
 
 Release branches should be named `release/vX.Y.Z` and opened as pull requests
 to `main` before merging. The Marketplace PAT check workflow runs only for
-non-draft same-repository `release/*` pull requests.
+non-draft same-repository `release/*` pull requests, including when a draft PR
+is marked ready for review.
 
-The automatic PR metadata job validates that:
+The workflow runs with `pull_request_target` so its definition comes from the
+trusted target branch. The automatic PR metadata job checks out the trusted base
+commit, fetches the PR head into a local git ref, and validates that:
 
 - `package.json` changes the version from the `main` base branch and the new
   version is greater than the base version.
@@ -74,23 +77,27 @@ store `VSCE_PAT` as an environment secret and `VSCE_PAT_EXPIRES_AT` as an
 environment variable in `YYYY-MM-DD` format. The job runs only after environment
 approval and validates that:
 
-For deployment branch restrictions, start with no restriction. If restrictions
-are required, allow the pull request merge ref pattern (`refs/pull/*/merge`);
-using only `release/*` can block this `pull_request` workflow before the
-environment approval step. If the repository is private, confirm with a test PR
-that the current GitHub plan supports required reviewers for protected
-environments.
-
 - `VSCE_PAT_EXPIRES_AT` is at least 14 days in the future.
 - `VSCE_PAT` still has Marketplace publish rights for the `yugook` publisher via
   `vsce verify-pat yugook`.
 
-The PAT job does not check out the PR branch or run project scripts; it installs
-the pinned `@vscode/vsce` CLI separately before reading `VSCE_PAT`. GitHub
-Actions cannot read the expiration date from the encrypted `VSCE_PAT` secret, so
-update `VSCE_PAT_EXPIRES_AT` whenever the Marketplace PAT is rotated. Review the
-release PR diff before approving the protected environment job, because approval
-makes the environment secret available to that job.
+The preview and stable publish workflows also use the same `marketplace-pat`
+environment, so the release PR check verifies the same `VSCE_PAT` that publish
+uses. The PAT verification job does not check out the PR branch or run project
+scripts; it installs the pinned `@vscode/vsce` CLI separately before reading
+`VSCE_PAT`. GitHub Actions cannot read the expiration date from the encrypted
+`VSCE_PAT` secret, so update `VSCE_PAT_EXPIRES_AT` whenever the Marketplace PAT
+is rotated. Review the release PR diff before approving the protected
+environment job, because approval makes the environment secret available to that
+job.
+
+For deployment branch and tag restrictions, start with no restriction. If
+restrictions are required, allow `main` for release PR verification and stable
+auto-release, `preview` for preview publishing, and `v*` tags for direct stable
+release workflow runs. Using only `release/*` blocks this `pull_request_target`
+workflow before the environment approval step. If the repository is private,
+confirm with a test PR that the current GitHub plan supports required reviewers
+for protected environments.
 
 ## Additional notes
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -54,6 +54,24 @@ never consume the number intended for the next stable release.
 5. Preflight tip: run `npm run package:verify` before tagging to catch version
    mismatches that would block vsce packaging.
 
+## Release PR checks
+
+Release branches should be named `release/vX.Y.Z` and opened as pull requests
+to `main` before merging. The Marketplace PAT check workflow runs only for
+non-draft same-repository `release/*` pull requests and validates that:
+
+- `package.json` changes the version from the `main` base branch.
+- The release branch version, `package.json`, `package-lock.json`,
+  `CHANGELOG.md`, and `dist/securezip-sbom.cdx.json` all agree on the same
+  `X.Y.Z` version.
+- Repository variable `VSCE_PAT_EXPIRES_AT` exists in `YYYY-MM-DD` format and is
+  at least 14 days in the future.
+- Secret `VSCE_PAT` still has Marketplace publish rights for the `yugook`
+  publisher via `npx vsce verify-pat yugook`.
+
+GitHub Actions cannot read the expiration date from the encrypted `VSCE_PAT`
+secret, so update `VSCE_PAT_EXPIRES_AT` whenever the Marketplace PAT is rotated.
+
 ## Additional notes
 
 - `npm run package` triggers SBOM generation (`scripts/generate-sbom.cjs`);

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -58,19 +58,32 @@ never consume the number intended for the next stable release.
 
 Release branches should be named `release/vX.Y.Z` and opened as pull requests
 to `main` before merging. The Marketplace PAT check workflow runs only for
-non-draft same-repository `release/*` pull requests and validates that:
+non-draft same-repository `release/*` pull requests.
 
-- `package.json` changes the version from the `main` base branch.
+The automatic PR metadata job validates that:
+
+- `package.json` changes the version from the `main` base branch and the new
+  version is greater than the base version.
 - The release branch version, `package.json`, `package-lock.json`,
   `CHANGELOG.md`, and `dist/securezip-sbom.cdx.json` all agree on the same
   `X.Y.Z` version.
-- Repository variable `VSCE_PAT_EXPIRES_AT` exists in `YYYY-MM-DD` format and is
-  at least 14 days in the future.
-- Secret `VSCE_PAT` still has Marketplace publish rights for the `yugook`
-  publisher via `npx vsce verify-pat yugook`.
 
-GitHub Actions cannot read the expiration date from the encrypted `VSCE_PAT`
-secret, so update `VSCE_PAT_EXPIRES_AT` whenever the Marketplace PAT is rotated.
+The Marketplace PAT verification job uses the protected `marketplace-pat`
+GitHub Environment. Configure that environment with required reviewers, then
+store `VSCE_PAT` as an environment secret and `VSCE_PAT_EXPIRES_AT` as an
+environment variable in `YYYY-MM-DD` format. The job runs only after environment
+approval and validates that:
+
+- `VSCE_PAT_EXPIRES_AT` is at least 14 days in the future.
+- `VSCE_PAT` still has Marketplace publish rights for the `yugook` publisher via
+  `vsce verify-pat yugook`.
+
+The PAT job does not check out the PR branch or run project scripts; it installs
+the pinned `@vscode/vsce` CLI separately before reading `VSCE_PAT`. GitHub
+Actions cannot read the expiration date from the encrypted `VSCE_PAT` secret, so
+update `VSCE_PAT_EXPIRES_AT` whenever the Marketplace PAT is rotated. Review the
+release PR diff before approving the protected environment job, because approval
+makes the environment secret available to that job.
 
 ## Additional notes
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -74,6 +74,13 @@ store `VSCE_PAT` as an environment secret and `VSCE_PAT_EXPIRES_AT` as an
 environment variable in `YYYY-MM-DD` format. The job runs only after environment
 approval and validates that:
 
+For deployment branch restrictions, start with no restriction. If restrictions
+are required, allow the pull request merge ref pattern (`refs/pull/*/merge`);
+using only `release/*` can block this `pull_request` workflow before the
+environment approval step. If the repository is private, confirm with a test PR
+that the current GitHub plan supports required reviewers for protected
+environments.
+
 - `VSCE_PAT_EXPIRES_AT` is at least 14 days in the future.
 - `VSCE_PAT` still has Marketplace publish rights for the `yugook` publisher via
   `vsce verify-pat yugook`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "securezip",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "securezip",
-      "version": "1.1.8",
+      "version": "1.1.9",
       "dependencies": {
         "archiver": "^7.0.1",
         "archiver-zip-encrypted": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "SecureZip",
   "description": "Securely export your project as a clean ZIP.",
   "publisher": "yugook",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "icon": "resources/securezip.png",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 概要

v1.1.9 リリースに向けた準備PRです。

## 変更内容

- `package.json` / `package-lock.json` を `1.1.9` に更新
- `CHANGELOG.md` に `1.1.9` のリリース内容を反映
- `dist/securezip-sbom.cdx.json` を `1.1.9` に更新
- release PR向けにバージョン整合性チェックを追加
- Marketplace PAT検証を保護された `marketplace-pat` Environment 承認後のjobに分離
- `VSCE_PAT` / `VSCE_PAT_EXPIRES_AT` の運用手順を `docs/releasing.md` に追記

## 確認内容

- `git diff --check`
- release PR metadata workflow の差分確認
- Marketplace PAT job がPRブランチをcheckoutせず、project scriptも実行しないことを確認

## リリース前の確認

GitHub側で `marketplace-pat` Environment を作成し、Required reviewers、Environment secret `VSCE_PAT`、Environment variable `VSCE_PAT_EXPIRES_AT` を設定してください。Deployment branch restriction を使う場合は、PR用の `refs/pull/*/merge` を考慮してください。