### PR TITLE
ドキュメントにPR運用ルールを追加

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## 概要
+
+-
+
+## 変更内容
+
+-
+
+## テスト
+
+- [ ] `npm run check-types`
+- [ ] `npm run lint`
+- [ ] `npm run test:unit`
+- [ ] その他:
+
+## 補足
+
+-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,10 +30,13 @@
 
 ## Development workflow
 - Prefer editing `src/`, `docs/`, `i18n/`, and `src/test/` when changing behavior.
+- When on `main` and asked to implement changes, create a topic branch before editing.
 - Use TypeScript, follow the configured ESLint rules, and add comments only when logic is non-obvious.
 - Prefer localized strings via `src/nls.ts` (see `docs/localization.md`); avoid hardcoding UI text.
 - Treat `dist/` and `out/` as generated outputs; do not hand-edit them.
 - Avoid committing build artifacts outside `dist/` (which is already tracked).
+- Write commit messages in Japanese and follow Google's commit message style: concise summary, blank line, then body when needed.
+- Write Pull Request titles and descriptions in Japanese.
 - Keep localization in sync:
   - Runtime strings: `src/nls.ts` + `i18n/nls.bundle.*.json`.
   - Contribution strings: `package.nls.json` + `package.nls.ja.json`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,9 @@ environment, run checks, and follow our release procedures.
 
 ## Development workflow
 
+When implementing changes from `main`, create a topic branch before editing.
+Avoid committing implementation work directly to `main`.
+
 1. **Install dependencies**
    ```bash
    npm install
@@ -35,6 +38,24 @@ features.
 - Add concise comments only when logic is non-obvious.
 - Avoid committing build artifacts outside the `dist/` folder that is already
   tracked.
+
+## Commit and pull request conventions
+
+- Write commit messages in Japanese and follow Google's commit message style:
+  a short summary line, a blank line, then a body when extra context is needed.
+- Keep the summary concise and describe what changed. Use the body to explain
+  why the change was made or to note important context.
+- Write pull request titles and descriptions in Japanese.
+- Use `.github/pull_request_template.md` when opening a pull request.
+
+Example commit message:
+
+```text
+ドキュメントにPR作成ルールを追加
+
+コミットとPull Requestの記述言語を日本語に統一するため、
+CONTRIBUTING.mdとAGENTS.mdに運用ルールを追記する。
+```
 
 ## Release process
 


### PR DESCRIPTION
## 概要

コミットメッセージと Pull Request の作成ルールをドキュメント化しました。

## 変更内容

- `CONTRIBUTING.md` に、`main` から実装する場合はトピックブランチを作成するルールを追加
- `CONTRIBUTING.md` に、日本語コミットメッセージと日本語 PR の運用ルールを追加
- `AGENTS.md` に、エージェント向けのブランチ作成・コミット・PR 作成ルールを追加
- `.github/pull_request_template.md` を追加し、日本語 PR テンプレートを用意

## テスト

- [x] `git diff --check`
- [ ] `npm run check-types`
- [ ] `npm run lint`
- [ ] `npm run test:unit`

## 補足

ドキュメントのみの変更のため、npm 系テストは未実行です。