### PR TITLE
[codex] CI/CDゲートを強化

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -10,6 +10,10 @@ on:
       - labeled
       - unlabeled
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   enable-auto-merge:
     if: >

--- a/.github/workflows/auto-release-on-main.yml
+++ b/.github/workflows/auto-release-on-main.yml
@@ -5,13 +5,19 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   create-release-tag:
     if: ${{ github.actor != 'github-actions[bot]' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       tag_name: ${{ steps.version.outputs.tag }}
       should_publish: ${{ steps.skip.outputs.value == 'false' && steps.existing.outputs.value == 'false' }}
@@ -28,6 +34,10 @@ jobs:
           VERSION=$(jq -r '.version' package.json)
           if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
             echo "Version not found in package.json" >&2
+            exit 1
+          fi
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::package.json version must be plain semver (x.y.z), got '$VERSION'."
             exit 1
           fi
           echo "value=$VERSION" >>"$GITHUB_OUTPUT"
@@ -69,6 +79,8 @@ jobs:
   publish-release:
     needs: create-release-tag
     if: ${{ needs.create-release-tag.outputs.should_publish == 'true' }}
+    permissions:
+      contents: write
     uses: ./.github/workflows/release.yml
     with:
       tag_name: ${{ needs.create-release-tag.outputs.tag_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,8 @@ jobs:
 
           committed_sbom="${RUNNER_TEMP:-/tmp}/committed-sbom.json"
           generated_sbom="${RUNNER_TEMP:-/tmp}/generated-sbom.json"
-          git show HEAD:dist/securezip-sbom.cdx.json | jq --sort-keys 'del(.serialNumber, .metadata.timestamp)' > "$committed_sbom"
-          jq --sort-keys 'del(.serialNumber, .metadata.timestamp)' dist/securezip-sbom.cdx.json > "$generated_sbom"
+          git show HEAD:dist/securezip-sbom.cdx.json | jq --sort-keys 'del(.serialNumber, .metadata.timestamp, .metadata.tools)' > "$committed_sbom"
+          jq --sort-keys 'del(.serialNumber, .metadata.timestamp, .metadata.tools)' dist/securezip-sbom.cdx.json > "$generated_sbom"
 
           if ! diff -u "$committed_sbom" "$generated_sbom"; then
             echo "::error::Generated SBOM content is out of date. Run npm run package and commit dist/securezip-sbom.cdx.json."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,13 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -38,6 +45,27 @@ jobs:
 
       - name: Package preflight (vsce)
         run: npm run package:verify
+
+      - name: Verify generated artifacts are committed
+        run: |
+          set -euo pipefail
+
+          if [ -n "$(git status --short -- dist ':!dist/securezip-sbom.cdx.json')" ]; then
+            echo "::error::Generated dist artifacts are out of date. Run npm run package and npm run package:verify, then commit dist changes."
+            git status --short -- dist ':!dist/securezip-sbom.cdx.json'
+            git diff --stat -- dist ':!dist/securezip-sbom.cdx.json'
+            exit 1
+          fi
+
+          committed_sbom="${RUNNER_TEMP:-/tmp}/committed-sbom.json"
+          generated_sbom="${RUNNER_TEMP:-/tmp}/generated-sbom.json"
+          git show HEAD:dist/securezip-sbom.cdx.json | jq --sort-keys 'del(.serialNumber, .metadata.timestamp)' > "$committed_sbom"
+          jq --sort-keys 'del(.serialNumber, .metadata.timestamp)' dist/securezip-sbom.cdx.json > "$generated_sbom"
+
+          if ! diff -u "$committed_sbom" "$generated_sbom"; then
+            echo "::error::Generated SBOM content is out of date. Run npm run package and commit dist/securezip-sbom.cdx.json."
+            exit 1
+          fi
 
       - name: Run unit tests
         run: npm run test:unit

--- a/.github/workflows/cleanup-preview-tags.yml
+++ b/.github/workflows/cleanup-preview-tags.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   cleanup:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,10 @@ on:
   schedule:
     - cron: '26 11 * * 4'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,6 +4,13 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/marketplace-pat-check.yml
+++ b/.github/workflows/marketplace-pat-check.yml
@@ -13,6 +13,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-release-pr:
     name: Validate release PR metadata

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - preview
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish-preview:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,20 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_call' && inputs.tag_name || github.ref_name }}
+  cancel-in-progress: false
+
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   publish-release:
     if: ${{ (github.event_name == 'push' && !endsWith(github.ref_name, '-preview')) || (github.event_name == 'workflow_call' && !endsWith(inputs.tag_name || '', '-preview')) }}
     runs-on: ubuntu-latest
     environment: marketplace-pat
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout repository
@@ -49,14 +55,26 @@ jobs:
 
       - name: Determine extension version
         id: version
+        env:
+          REQUESTED_TAG: ${{ github.event_name == 'workflow_call' && inputs.tag_name || github.ref_name }}
         run: |
+          set -euo pipefail
           VERSION=$(jq -r '.version' package.json)
           if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
             echo "Version not found in package.json" >&2
             exit 1
           fi
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::package.json version must be plain semver (x.y.z), got '$VERSION'."
+            exit 1
+          fi
+          EXPECTED_TAG="v${VERSION}"
+          if [ "$REQUESTED_TAG" != "$EXPECTED_TAG" ]; then
+            echo "::error::Release tag '$REQUESTED_TAG' must match package.json version '$VERSION' as '$EXPECTED_TAG'."
+            exit 1
+          fi
           echo "plain=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=$EXPECTED_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Build VSIX bundle
         run: npm run package

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -8,6 +8,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   npm-audit:
     name: Audit dependencies for CVEs

--- a/.github/workflows/tag-after-release.yml
+++ b/.github/workflows/tag-after-release.yml
@@ -5,6 +5,13 @@ on:
     workflows: ["Publish Release", "Publish Preview"]
     types: [completed]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.name }}-${{ github.event.workflow_run.head_sha }}
+  cancel-in-progress: false
+
 jobs:
   tag:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}


### PR DESCRIPTION
## 概要

CI/CD の安全性と再現性を高めるため、GitHub Actions のゲートを強化します。

## 変更内容

- CI に生成物差分チェックを追加
- SBOM 比較では毎回変わる `serialNumber` と `metadata.timestamp` を正規化
- リリースタグと `package.json` の version 一致チェックを追加
- `package.json` version が plain semver であることを検証
- 各 workflow に `concurrency` を追加
- workflow の `permissions` を明示し、必要な job のみ `contents: write` を付与

## 影響

- stale な SBOM やリリースタグ不一致を CI/CD で検出できます。
- PR や push の古い workflow 実行が自動キャンセルされ、Actions の待ち時間と消費を抑えます。
- release/tag 系の実行は途中キャンセルされないようにしています。

## 確認

- `npm run package`
- `npm run package:verify`
- `git diff --check`
- `.github/workflows/*.yml` を `js-yaml` で構文パース

## 補足

- ローカル環境に `actionlint` がなかったため、`actionlint` は未実行です。