### PR TITLE
actionlint ワークフローを追加

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,25 @@
+name: Actionlint
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - release/**
+      - TestFlight/**
+      - testflight/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check workflow files
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color

--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -17,10 +17,10 @@ concurrency:
 jobs:
   enable-auto-merge:
     if: >
-      ${{ github.event.pull_request.user.login == 'dependabot[bot]' &&
-          github.event.pull_request.base.ref == 'main' &&
-          github.event.pull_request.draft == false &&
-          contains(github.event.pull_request.labels.*.name, 'safe-to-automerge') }}
+      github.event.pull_request.user.login == 'dependabot[bot]' &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.draft == false &&
+      contains(github.event.pull_request.labels.*.name, 'safe-to-automerge')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/auto-release-on-main.yml
+++ b/.github/workflows/auto-release-on-main.yml
@@ -45,8 +45,10 @@ jobs:
 
       - name: Check for skip directive
         id: skip
+        env:
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: |
-          if [[ "${{ github.event.head_commit.message }}" == *"[skip-release]"* ]]; then
+          if [[ "$HEAD_COMMIT_MESSAGE" == *"[skip-release]"* ]]; then
             echo "value=true" >>"$GITHUB_OUTPUT"
           else
             echo "value=false" >>"$GITHUB_OUTPUT"


### PR DESCRIPTION
## 変更内容
- GitHub Actions workflow を検査する `Actionlint` workflow を追加しました。
- `pull_request`、`main` / `release/**` / `TestFlight/**` / `testflight/**` への push、手動実行で動作します。
- `rhysd/actionlint:1.7.12` を固定し、`timeout-minutes: 5` と最小権限の `contents: read` を設定しました。
- 導入後に検出された既存 workflow の actionlint 指摘を修正しました。

## 修正した指摘
- `auto-merge-dependabot.yml` の job-level `if:` から不要な `${{ }}` ラップを外しました。
- `auto-release-on-main.yml` の commit message 参照を inline shell 直挿しから env 経由に変更しました。

## 影響
- workflow の構文や expression の問題を PR 時点で検出しやすくなります。
- アプリケーションコードや拡張機能の実行時動作には影響しません。

## 確認
- `git diff --cached --check`
- 追加した workflow 内容の読み返し
- 末尾空白チェック
- actionlint の CI ログで検出された指摘内容に対応

## 補足
- ローカル環境では `docker` / `actionlint` が PATH にないため、同じ Docker image でのローカル再実行は未実施です。