### PR TITLE
PAT期限メタデータチェックを削除

### DIFF
--- a/.github/workflows/marketplace-pat-check.yml
+++ b/.github/workflows/marketplace-pat-check.yml
@@ -110,37 +110,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check Marketplace PAT expiry metadata
-        env:
-          VSCE_PAT_EXPIRES_AT: ${{ vars.VSCE_PAT_EXPIRES_AT }}
-        run: |
-          set -euo pipefail
-
-          if [ -z "${VSCE_PAT_EXPIRES_AT:-}" ]; then
-            echo "::error::Environment variable VSCE_PAT_EXPIRES_AT is required in YYYY-MM-DD format."
-            exit 1
-          fi
-
-          python3 - <<'PY'
-          import datetime as dt
-          import os
-          import sys
-
-          try:
-              expires = dt.date.fromisoformat(os.environ["VSCE_PAT_EXPIRES_AT"])
-          except ValueError:
-              print("::error::VSCE_PAT_EXPIRES_AT must use YYYY-MM-DD format.")
-              sys.exit(1)
-
-          today = dt.datetime.now(dt.timezone.utc).date()
-          days = (expires - today).days
-          print(f"VSCE_PAT expires in {days} days ({expires.isoformat()})")
-
-          if days < 14:
-              print("::error::VSCE_PAT expires too soon for a release PR.")
-              sys.exit(1)
-          PY
-
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -73,11 +73,9 @@ commit, fetches the PR head into a local git ref, and validates that:
 
 The Marketplace PAT verification job uses the protected `marketplace-pat`
 GitHub Environment. Configure that environment with required reviewers, then
-store `VSCE_PAT` as an environment secret and `VSCE_PAT_EXPIRES_AT` as an
-environment variable in `YYYY-MM-DD` format. The job runs only after environment
+store `VSCE_PAT` as an environment secret. The job runs only after environment
 approval and validates that:
 
-- `VSCE_PAT_EXPIRES_AT` is at least 14 days in the future.
 - `VSCE_PAT` still has Marketplace publish rights for the `yugook` publisher via
   `vsce verify-pat yugook`.
 
@@ -85,9 +83,7 @@ The preview and stable publish workflows also use the same `marketplace-pat`
 environment, so the release PR check verifies the same `VSCE_PAT` that publish
 uses. The PAT verification job does not check out the PR branch or run project
 scripts; it installs the pinned `@vscode/vsce` CLI separately before reading
-`VSCE_PAT`. GitHub Actions cannot read the expiration date from the encrypted
-`VSCE_PAT` secret, so update `VSCE_PAT_EXPIRES_AT` whenever the Marketplace PAT
-is rotated. Review the release PR diff before approving the protected
+`VSCE_PAT`. Review the release PR diff before approving the protected
 environment job, because approval makes the environment secret available to that
 job.
 


### PR DESCRIPTION
## 概要

Marketplace PAT Check から `VSCE_PAT_EXPIRES_AT` による期限メタデータ確認を削除します。

## 変更内容

- `Verify Marketplace PAT` job から PAT 期限メタデータ確認ステップを削除
- リリース手順ドキュメントから `VSCE_PAT_EXPIRES_AT` の設定要件を削除

## 影響

- `marketplace-pat` Environment では `VSCE_PAT` secret のみが必要になります。
- PAT が有効かどうかは引き続き `vsce verify-pat yugook` で確認します。

## 検証

- `git diff --check HEAD~1..HEAD`
- `rg -n "VSCE_PAT_EXPIRES_AT|expires too soon|expiry metadata" .github/workflows/marketplace-pat-check.yml docs/releasing.md` が一致なし

補足: ローカルに `actionlint` が無く、`npx --no-install actionlint` は実行できませんでした。