### PR TITLE
リリースタグ判定と手動復旧導線を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name to publish (e.g. v1.0.0)'
+        required: true
+        type: string
   workflow_call:
     inputs:
       tag_name:
@@ -12,7 +18,7 @@ on:
         type: string
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_call' && inputs.tag_name || github.ref_name }}
+  group: ${{ github.workflow }}-${{ inputs.tag_name || github.ref_name }}
   cancel-in-progress: false
 
 permissions:
@@ -20,7 +26,7 @@ permissions:
 
 jobs:
   publish-release:
-    if: ${{ (github.event_name == 'push' && !endsWith(github.ref_name, '-preview')) || (github.event_name == 'workflow_call' && !endsWith(inputs.tag_name || '', '-preview')) }}
+    if: ${{ !endsWith(inputs.tag_name || github.ref_name, '-preview') }}
     runs-on: ubuntu-latest
     environment: marketplace-pat
     permissions:
@@ -30,6 +36,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.tag_name || github.ref }}
           fetch-depth: 0
 
       - name: Set up Node.js
@@ -56,7 +63,7 @@ jobs:
       - name: Determine extension version
         id: version
         env:
-          REQUESTED_TAG: ${{ github.event_name == 'workflow_call' && inputs.tag_name || github.ref_name }}
+          REQUESTED_TAG: ${{ inputs.tag_name || github.ref_name }}
         run: |
           set -euo pipefail
           VERSION=$(jq -r '.version' package.json)
@@ -75,6 +82,10 @@ jobs:
           fi
           echo "plain=$VERSION" >> "$GITHUB_OUTPUT"
           echo "tag=$EXPECTED_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Determine release commit
+        id: release_ref
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Build VSIX bundle
         run: npm run package
@@ -131,6 +142,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ steps.version.outputs.tag }}
           VSIX_NAME: securezip-${{ steps.version.outputs.plain }}.vsix
+          RELEASE_SHA: ${{ steps.release_ref.outputs.sha }}
         run: |
           set -euo pipefail
           if [ ! -f "$VSIX_NAME" ]; then
@@ -140,8 +152,8 @@ jobs:
           if gh release view "$TAG_NAME" >/dev/null 2>&1; then
             echo "Release $TAG_NAME exists. Updating assets and notes."
             gh release upload "$TAG_NAME" "$VSIX_NAME" --clobber
-            gh release edit "$TAG_NAME" --draft --title "$TAG_NAME" --notes-file release-notes.md --target "$GITHUB_SHA"
+            gh release edit "$TAG_NAME" --draft --title "$TAG_NAME" --notes-file release-notes.md --target "$RELEASE_SHA"
           else
             echo "Creating draft release $TAG_NAME."
-            gh release create "$TAG_NAME" "$VSIX_NAME" --draft --title "$TAG_NAME" --notes-file release-notes.md --target "$GITHUB_SHA"
+            gh release create "$TAG_NAME" "$VSIX_NAME" --draft --title "$TAG_NAME" --notes-file release-notes.md --target "$RELEASE_SHA"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
-          ref: ${{ inputs.tag_name || github.ref }}
+          ref: ${{ github.event_name == 'push' && github.sha || format('refs/tags/{0}', inputs.tag_name) }}
           fetch-depth: 0
 
       - name: Set up Node.js

--- a/.github/workflows/tag-after-release.yml
+++ b/.github/workflows/tag-after-release.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   tag:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && (github.event.workflow_run.name != 'Publish Release' || github.event.workflow_run.event != 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -58,7 +58,9 @@ never consume the number intended for the next stable release.
 
 If the auto-release workflow creates the `vX.Y.Z` tag but the publish job fails
 afterward, do not delete or recreate the tag. Re-run the `Publish Release`
-workflow manually with `tag_name` set to the existing tag, such as `v1.2.0`.
+workflow manually from the `main` branch by selecting `main` in the GitHub UI
+`Use workflow from` dropdown, then set `tag_name` to the existing tag, such as
+`v1.2.0`.
 The workflow checks out that tag, verifies it matches `package.json`, publishes
 with `--skip-duplicate`, and creates or updates the draft GitHub Release.
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -9,6 +9,8 @@ contributors (humans or automation such as Codex) follow the exact same flow.
   `vsce publish --pre-release --skip-duplicate`.
 - `main` branch &rarr; `.github/workflows/auto-release-on-main.yml` tags the
   commit, then reuses `.github/workflows/release.yml` to ship the stable build.
+- `.github/workflows/release.yml` can also be run manually with an existing
+  `vX.Y.Z` tag to recover a failed stable publish job.
 - `tag-after-release.yml` mirrors the version back to a git tag (`vX.Y.Z` or
   `vX.Y.Z-preview`), so never delete the tags manually.
 
@@ -45,7 +47,7 @@ never consume the number intended for the next stable release.
 2. Bump `package.json` to the next semver (e.g. `npm version 1.0.10`) because
    the preview already consumed `1.0.9`. Update the changelog if necessary.
 3. Push to `main`. The auto-release workflow will:
-   - create the `v1.0.9` tag,
+   - create the `v1.0.10` tag,
    - run type checks, lint, `npm run package`, unit/integration tests,
    - publish to the Marketplace with `npx vsce publish --skip-duplicate`,
    - create a draft GitHub Release with the VSIX artifact.
@@ -53,6 +55,12 @@ never consume the number intended for the next stable release.
    `[skip-release]` in the commit message.
 5. Preflight tip: run `npm run package:verify` before tagging to catch version
    mismatches that would block vsce packaging.
+
+If the auto-release workflow creates the `vX.Y.Z` tag but the publish job fails
+afterward, do not delete or recreate the tag. Re-run the `Publish Release`
+workflow manually with `tag_name` set to the existing tag, such as `v1.2.0`.
+The workflow checks out that tag, verifies it matches `package.json`, publishes
+with `--skip-duplicate`, and creates or updates the draft GitHub Release.
 
 ## Release PR checks
 


### PR DESCRIPTION
## 概要
- `Publish Release` workflow に `workflow_dispatch` を追加し、既存タグを指定して手動再実行できるようにしました。
- `workflow_call` 実行時に `github.ref_name` の `main` を release tag として扱わないよう、`inputs.tag_name || github.ref_name` を共通のタグ入力として使う形に修正しました。
- tag push では `github.sha`、手動/再利用実行では `refs/tags/<tag_name>` を checkout するようにし、未修飾 ref による branch/tag 衝突を避けました。
- 手動復旧時も指定タグを checkout し、draft GitHub Release の target に checkout 後の commit SHA を使うようにしました。
- `Publish Release` の手動復旧 run では `tag-after-release.yml` が再タグ付けしないようにしました。
- release 手順ドキュメントに、タグ作成後に publish job だけ失敗した場合の復旧手順と `Use workflow from: main` の注意を追記しました。

## 原因
`auto-release-on-main.yml` は `v1.2.0` を `release.yml` に渡していましたが、呼び出し先で release tag の判定に `github.ref_name` の `main` が使われ、`package.json` の `1.2.0` から期待される `v1.2.0` と一致せず失敗していました。

## v1.2.0 の復旧
この PR を `main` に取り込んだあと、Actions の `Publish Release` を手動実行してください。GitHub UI の `Use workflow from` は `main` を選び、入力 `tag_name` に `v1.2.0` を指定します。既存の `v1.2.0` タグは削除・再作成しません。

## 検証
- `git diff --check`
- `node -e "const fs=require('fs'); const yaml=require('js-yaml'); for (const file of ['.github/workflows/release.yml','.github/workflows/tag-after-release.yml']) { yaml.load(fs.readFileSync(file,'utf8')); console.log(file+' YAML parsed'); }"`
- 既存 `v1.2.0` タグと `package.json` version `1.2.0` の一致確認