### PR TITLE
fix: Dependabot生成物Artifactのアップロード先を修正

### DIFF
--- a/.github/workflows/build-dependabot-generated-artifacts.yml
+++ b/.github/workflows/build-dependabot-generated-artifacts.yml
@@ -112,6 +112,6 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: dependabot-generated
-          path: .dependabot-generated
+          path: dependabot-generated
           if-no-files-found: error
           retention-days: 1


### PR DESCRIPTION
## 概要

Dependabot生成物同期ワークフローのArtifactアップロード先を修正します。

## 変更内容

- `actions/upload-artifact@v7`のパスを`.dependabot-generated`から`dependabot-generated`へ変更
- Buildワークフローの生成先・Artifact名・Syncワークフローのダウンロード先を一致させる

## 背景

`upload-artifact@v7`は隠しディレクトリを標準では対象外とするため、Artifactが見つからずBuildワークフローが失敗していました。その結果、Dependabot PRのSBOMを同期できず、`CI / package`で生成済みSBOMとの差分が検出されていました。

## 検証

- 変更はワークフロー1ファイル・1行のみ
- `git diff --check` 実行済み
- 関連するBuild/Syncワークフローのパス一致を確認
- Actionlintはローカル未導入のため、GitHub Actions上のチェックで検証予定